### PR TITLE
Fix dashboard chart overflow

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2124,3 +2124,15 @@ select:focus {
     height: 10px;
   }
 }
+
+/* Ensure charts fit within cards without overflow */
+.stat-card,
+.chart-card {
+  max-height: none;
+  height: auto;
+}
+
+.chart-container,
+.svg-chart {
+  height: auto;
+}


### PR DESCRIPTION
## Summary
- remove fixed max-height from stat/chart cards so distribution charts stay within cards
- allow chart containers and SVG charts to auto-expand

## Testing
- `pytest -q` *(fails: ImportError: Google Cloud Text-to-Speech library not installed)*
- `PYTHONPATH=. pytest tests -q` *(fails: ModuleNotFoundError: No module named 'main')*


------
https://chatgpt.com/codex/tasks/task_e_68b0f79aa3b4833383385381142eb384