### PR TITLE
Ensure charts and legends display without clipping

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2072,10 +2072,8 @@ select:focus {
   flex: 1;
 }
 
-/* 古い凡例要素を非表示 */
-#region-legend, #category-legend {
-  display: none !important;
-}
+/* Legend containers should be visible */
+/* (display rule removed to show legends) */
 
 /* Chart Card Specific Styles */
 .chart-card .pie-chart-container {
@@ -2126,13 +2124,41 @@ select:focus {
 }
 
 /* Ensure charts fit within cards without overflow */
-.stat-card,
-.chart-card {
+.stat-card {
   max-height: none;
   height: auto;
 }
 
-.chart-container,
+.chart-card {
+  max-height: none;
+  height: auto;
+  overflow: visible;
+}
+
+.chart-container {
+  height: auto;
+  max-height: none;
+  overflow: visible;
+}
+
 .svg-chart {
   height: auto;
+}
+
+@media (max-width: 768px) {
+  .chart-card,
+  .chart-container {
+    height: auto;
+    max-height: none;
+    overflow: visible;
+  }
+}
+
+@media (max-width: 480px) {
+  .chart-card,
+  .chart-container {
+    height: auto;
+    max-height: none;
+    overflow: visible;
+  }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1209,15 +1209,9 @@ class MarketNewsApp {
             console.log('🚨 最終統計 - 地域:', regionStats);
             console.log('🚨 最終統計 - カテゴリ:', categoryStats);
             
-            // チャート描画実行
+            // チャート描画実行 (凡例は各描画関数内で挿入)
             this.renderRegionChart(regionStats);
             this.renderCategoryChart(categoryStats);
-
-            // 凡例の描画
-            const regionColors = ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF'];
-            const categoryColors = ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40'];
-            this.generateCustomLegend('region-legend', regionStats, regionColors, (k) => this.getRegionDisplayName(k));
-            this.generateCustomLegend('category-legend', categoryStats, categoryColors, (k) => this.getCategoryDisplayName(k));
             
             console.log('✅ チャート描画完了');
         } catch (error) {
@@ -1325,15 +1319,18 @@ class MarketNewsApp {
         legend += '</div>';
         console.log('🚨 生成された地域凡例HTML:', legend);
         
-        // 全体を統合して挿入
-        const fullContent = `
+        // チャートSVGのみをコンテナに挿入
+        container.innerHTML = `
             <div class="pie-chart-container">
                 ${svg}
             </div>
-            ${legend}
         `;
-        
-        container.innerHTML = fullContent;
+
+        // 生成した凡例を専用要素に挿入
+        const legendContainer = document.getElementById('region-legend');
+        if (legendContainer) {
+            legendContainer.innerHTML = legend;
+        }
         
         console.log('✅ 地域円グラフ描画完了');
     }
@@ -1437,15 +1434,18 @@ class MarketNewsApp {
         legend += '</div>';
         console.log('🚨 生成されたカテゴリ凡例HTML:', legend);
         
-        // 全体を統合して挿入
-        const fullContent = `
+        // チャートSVGのみをコンテナに挿入
+        container.innerHTML = `
             <div class="pie-chart-container">
                 ${svg}
             </div>
-            ${legend}
         `;
-        
-        container.innerHTML = fullContent;
+
+        // 生成した凡例を専用要素に挿入
+        const legendContainer = document.getElementById('category-legend');
+        if (legendContainer) {
+            legendContainer.innerHTML = legend;
+        }
         
         console.log('✅ カテゴリ円グラフ描画完了');
     }


### PR DESCRIPTION
## Summary
- remove fixed heights and overflow constraints on chart containers
- display region and category legends and render them outside the chart svg

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: Import error for google-cloud-texttospeech)*
- `pip install google-cloud-texttospeech>=2.16.0` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b1194d5eb08333bbc6e5eb883dc846