### PR TITLE
fix: allow charts and legends to expand within cards

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -61,14 +61,14 @@
 
 /* チャート付き統計カード */
 .chart-card {
-  min-height: 320px;
-  max-height: 320px;
   padding: 1rem;
   grid-column: span 1;
   position: relative;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
+  height: auto;
+  max-height: none;
+  overflow: visible;
 }
 
 .chart-card .stat-label {
@@ -77,11 +77,8 @@
   text-align: center;
 }
 
-/* チャートコンテナの高さ制限を強化 */
+/* チャートコンテナ */
 .chart-container {
-  height: 260px;
-  max-height: 260px;
-  overflow: hidden;
   display: flex;
   flex-direction: column !important;
   align-items: center;
@@ -89,6 +86,9 @@
   padding: 0.5rem;
   order: 1;
   flex: 1;
+  height: auto;
+  max-height: none;
+  overflow: visible;
 }
 
 /* 数値表示統計カードのスタイル調整 */
@@ -190,11 +190,12 @@
     min-height: 320px;
     max-height: 320px;
   }
-  
+
   .chart-card {
-    min-height: 320px;
-    max-height: 320px;
     grid-column: span 1;
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
   
   .stat-card canvas {
@@ -209,7 +210,9 @@
   }
   
   .chart-container {
-    height: 200px;
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
   
   .grid {
@@ -237,12 +240,13 @@
     max-height: 320px;
     padding: 1rem 0.75rem;
   }
-  
+
   .chart-card {
-    min-height: 320px;
-    max-height: 320px;
     grid-column: span 1;
     padding: 1rem 0.75rem;
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
   
   .stat-card canvas {
@@ -257,7 +261,9 @@
   }
   
   .chart-container {
-    height: 180px;
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
   
   .stat-label {
@@ -420,7 +426,9 @@ html[data-theme] * {
   justify-content: center;
   gap: 0.5rem;
   width: 100%;
-  height: 200px;
+  height: auto;
+  max-height: none;
+  overflow: visible;
   margin-bottom: 0.25rem;
 }
 
@@ -1119,17 +1127,20 @@ html[data-theme] * {
     min-height: 320px;
     max-height: 320px;
   }
-  
+
   .chart-card {
     grid-column: span 1;
-    min-height: 320px;
-    max-height: 320px;
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
-  
+
   .chart-container {
     flex-direction: column;
     gap: 0.25rem;
-    height: 200px;
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
   
   .stat-card canvas {
@@ -1231,11 +1242,13 @@ html[data-theme] * {
     min-height: 320px;
     max-height: 320px;
   }
-  
+
   .chart-container {
     flex-direction: column;
     gap: 0.25rem;
-    height: 160px;
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
   
   .stat-card canvas {
@@ -2123,42 +2136,3 @@ select:focus {
   }
 }
 
-/* Ensure charts fit within cards without overflow */
-.stat-card {
-  max-height: none;
-  height: auto;
-}
-
-.chart-card {
-  max-height: none;
-  height: auto;
-  overflow: visible;
-}
-
-.chart-container {
-  height: auto;
-  max-height: none;
-  overflow: visible;
-}
-
-.svg-chart {
-  height: auto;
-}
-
-@media (max-width: 768px) {
-  .chart-card,
-  .chart-container {
-    height: auto;
-    max-height: none;
-    overflow: visible;
-  }
-}
-
-@media (max-width: 480px) {
-  .chart-card,
-  .chart-container {
-    height: auto;
-    max-height: none;
-    overflow: visible;
-  }
-}


### PR DESCRIPTION
## Summary
- remove fixed heights and overflow restrictions from chart cards and containers so charts and legends remain fully visible
- adjust responsive breakpoints to keep auto height and visible overflow on tablets and mobiles

## Testing
- `pytest tests test_category_region_fix.py test_classification_fix.py test_flash_lite_accuracy.py` *(errors: module/config missing & test collection failures)*
- `python -m flake8` *(module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b118d4d8508333a47cbf0f26e6e41f