### PR TITLE
Revamp social preview image layout

### DIFF
--- a/src/core/social_content_generator.py
+++ b/src/core/social_content_generator.py
@@ -4,7 +4,7 @@
 
 import logging
 from datetime import datetime
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import pytz
 import json
 from pathlib import Path


### PR DESCRIPTION
## Summary
- center social preview header and add underlined date
- render top topics as full-width cards and drop placeholder chart
- import Optional in social content generator to fix workflow crash

## Testing
- `python scripts/dev/generate_social_demo.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'config')*
- `PYTHONPATH=. pytest` *(fails: SystemExit: 1 in deprecated tests)*
- `PYTHONPATH=. pytest tests` *(fails: 5 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d90ce1308333a7d1eceb8a962b68