### PR TITLE
fix(scrapers): Reuters 本文取得を Selenium 化、Bloomberg 待機セレクター修正

### DIFF
--- a/scrapers/bloomberg.py
+++ b/scrapers/bloomberg.py
@@ -16,6 +16,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 import tempfile
 from pathlib import Path
+import shutil
 
 from src.config.app_config import get_config
 
@@ -23,97 +24,127 @@ from src.config.app_config import get_config
 config = get_config()
 scraping_config = config.scraping
 
+# Bloomberg は bloomberg.co.jp → bloomberg.com/jp にリダイレクトされるが
+# Selenium でアクセスすると bloomberg.co.jp のまま記事一覧が取得できる
+_BLOOMBERG_BASE = "https://www.bloomberg.co.jp"
+
+# 記事 URL として認める正規表現（bloomberg.co.jp / bloomberg.com 両方）
+_ARTICLE_URL_RE = re.compile(
+    r'https?://(?:www\.bloomberg\.co\.jp|www\.bloomberg\.com)/(?:news/articles|news/videos|markets|technology|business|finance|economics)',
+    re.I,
+)
+
+
 def scrape_bloomberg_article_body(article_url: str, timeout: int = 15) -> str:
-    """指定されたBloomberg記事URLから本文を抽出する"""
+    """指定された Bloomberg 記事 URL から本文を抽出する (requests ベース)"""
     headers = {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36',
+        'User-Agent': (
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+            '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+        ),
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.5',
+        'Accept-Language': 'ja,en-US;q=0.7,en;q=0.3',
         'Accept-Encoding': 'gzip, deflate, br',
         'Connection': 'keep-alive',
         'Upgrade-Insecure-Requests': '1',
         'Sec-Fetch-Dest': 'document',
         'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'none'
+        'Sec-Fetch-Site': 'none',
+        'Referer': 'https://www.bloomberg.co.jp/',
     }
-    
-    # リトライ機能付きで記事本文を取得
+
     max_retries = 2
     for attempt in range(max_retries + 1):
         try:
-            # リトライ時はタイムアウトを延長
             current_timeout = timeout if attempt == 0 else timeout + 10
-            print(f"  [記事本文取得] Bloomberg URL: {article_url} を処理中... (試行 {attempt + 1}/{max_retries + 1}, タイムアウト: {current_timeout}秒)")
-            
+            print(
+                f"  [Bloomberg本文取得] URL: {article_url} "
+                f"(試行 {attempt + 1}/{max_retries + 1}, タイムアウト: {current_timeout}秒)"
+            )
+
             response = requests.get(article_url, headers=headers, timeout=current_timeout)
             response.raise_for_status()
             response.encoding = response.apparent_encoding
-            
+
             soup = BeautifulSoup(response.content, 'html.parser')
-            
-            body_container = soup.find('div', class_=re.compile(r'(body-copy|article-body|content-well)'))
+
+            # 本文コンテナを複数パターンで探索
+            body_container = None
+            container_candidates = [
+                soup.find('div', class_=re.compile(r'body-copy|article-body|content-well', re.I)),
+                soup.find('article'),
+                soup.find('main'),
+                soup.find('div', class_=re.compile(r'story.*content|content.*story', re.I)),
+            ]
+            for candidate in container_candidates:
+                if candidate:
+                    body_container = candidate
+                    break
+
             if not body_container:
-                print(f"  [記事本文取得] 標準本文コンテナが見つからないため、article要素を検索: {article_url}")
-                article_tag = soup.find('article')
-                if not article_tag: 
-                    print(f"  [記事本文取得] article要素も見つかりません: {article_url}")
-                    if attempt < max_retries:
-                        print(f"  [記事本文取得] リトライします...")
-                        time.sleep(2)
-                        continue
-                    return ""
-                for unwanted_tag in article_tag.find_all(['script', 'style', 'aside', 'figure', 'figcaption', 'iframe', 'header', 'footer', 'nav']):
-                    unwanted_tag.decompose()
-                body_container = article_tag
-
-            paragraphs = body_container.find_all('p')
-            paragraphs_text = [p.get_text(separator=' ', strip=True) for p in paragraphs if p.get_text(strip=True)] if paragraphs else []
-            
-            if not paragraphs_text:
-                print(f"  [記事本文取得] p要素が見つからないため、全テキストを取得: {article_url}")
-                full_text = body_container.get_text(separator='\n', strip=True)
-                paragraphs_text = [line.strip() for line in full_text.split('\n') if line.strip()]
-
-            article_text = '\n'.join(paragraphs_text)
-            if len(article_text.strip()) < 50:
-                print(f"  [記事本文取得] Bloomberg本文が短すぎます (長さ: {len(article_text)}文字): {article_url}")
+                print(f"  [Bloomberg本文取得] 本文コンテナが見つかりません: {article_url}")
                 if attempt < max_retries:
-                    print(f"  [記事本文取得] リトライします...")
+                    time.sleep(2)
+                    continue
+                return ""
+
+            # 不要タグを除去
+            for unwanted in body_container.find_all(
+                ['script', 'style', 'aside', 'figure', 'figcaption', 'iframe', 'header', 'footer', 'nav']
+            ):
+                unwanted.decompose()
+
+            paragraphs = [
+                p.get_text(separator=' ', strip=True)
+                for p in body_container.find_all('p')
+                if p.get_text(strip=True)
+            ]
+
+            if not paragraphs:
+                full_text = body_container.get_text(separator='\n', strip=True)
+                paragraphs = [l.strip() for l in full_text.split('\n') if l.strip()]
+
+            article_text = '\n'.join(paragraphs)
+            if len(article_text.strip()) < 50:
+                print(f"  [Bloomberg本文取得] 本文が短すぎます (長さ: {len(article_text)}文字): {article_url}")
+                if attempt < max_retries:
                     time.sleep(2)
                     continue
             else:
-                print(f"  [記事本文取得] Bloomberg本文取得成功 (長さ: {len(article_text)}文字): {article_url}")
-            
+                print(f"  [Bloomberg本文取得] 成功 (長さ: {len(article_text)}文字): {article_url}")
+
             return re.sub(r'\s+', ' ', article_text).strip()
-            
+
         except (requests.exceptions.RequestException, requests.exceptions.Timeout) as e:
-            print(f"  [本文取得エラー] Bloomberg記事 ({article_url}) の取得に失敗 (試行 {attempt + 1}): {e}")
+            print(f"  [Bloomberg本文取得エラー] {article_url} (試行 {attempt + 1}): {e}")
             if attempt < max_retries:
-                print(f"  [記事本文取得] {2}秒後にリトライします...")
                 time.sleep(2)
                 continue
         except Exception as e:
-            print(f"  [本文取得エラー] Bloomberg記事 ({article_url}) の解析中に予期せぬエラー: {e}")
+            print(f"  [Bloomberg本文取得エラー] 解析中に予期せぬエラー: {e}")
             if attempt < max_retries:
-                print(f"  [記事本文取得] リトライします...")
                 time.sleep(2)
                 continue
-    
-    # 全ての試行が失敗した場合
-    print(f"  [本文取得失敗] 全ての試行が失敗しました: {article_url}")
+
+    print(f"  [Bloomberg本文取得失敗] 全試行失敗: {article_url}")
     return ""
 
+
 def scrape_bloomberg_top_page_articles(hours_limit: int, exclude_keywords: list) -> list:
-    """Bloombergのトップページから記事情報を収集する"""
-    base_url = "https://www.bloomberg.co.jp"
-    
+    """Bloomberg トップページから記事情報を収集する (Selenium ベース)"""
+
+    user_data_dir = tempfile.mkdtemp(prefix="chrome-bloomberg-", dir=str(Path.cwd()))
+
     chrome_options = Options()
     chrome_options.add_argument("--headless")
     chrome_options.add_argument("--no-sandbox")
     chrome_options.add_argument("--disable-dev-shm-usage")
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument('user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36')
+    chrome_options.add_argument(
+        "user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    )
     chrome_options.add_argument("--blink-settings=imagesEnabled=false")
     chrome_options.add_argument("--disable-extensions")
     chrome_options.add_argument("--disable-plugins")
@@ -121,112 +152,142 @@ def scrape_bloomberg_top_page_articles(hours_limit: int, exclude_keywords: list)
     chrome_options.add_argument("--allow-running-insecure-content")
     chrome_options.add_argument("--disable-features=VizDisplayCompositor")
     chrome_options.add_argument("--disable-blink-features=AutomationControlled")
+    chrome_options.add_argument("--remote-debugging-port=0")
     chrome_options.add_experimental_option("useAutomationExtension", False)
     chrome_options.add_experimental_option("excludeSwitches", ["enable-automation"])
     chrome_options.add_experimental_option('prefs', {
         'profile.default_content_setting_values.notifications': 2,
         'profile.default_content_settings.popups': 0,
-        'profile.managed_default_content_settings.images': 2
+        'profile.managed_default_content_settings.images': 2,
     })
-    # ユーザーディレクトリ衝突対策（ワークスペース内に一時プロファイルを作成）
-    user_data_dir = tempfile.mkdtemp(prefix="chrome-profile-", dir=str(Path.cwd()))
     chrome_options.add_argument(f"--user-data-dir={user_data_dir}")
 
     driver = None
     print("\n--- Bloomberg記事のスクレイピング開始 ---")
-    
+
     articles_to_process = []
     processed_urls = set()
 
     try:
         driver = webdriver.Chrome(options=chrome_options)
-        driver.set_page_load_timeout(scraping_config.selenium_timeout)
-        wait = WebDriverWait(driver, scraping_config.selenium_timeout)
-        
-        print(f"  Bloomberg: トップページ ({base_url}) を取得中...")
+        driver.set_page_load_timeout(scraping_config.page_load_timeout)
+
+        print(f"  Bloomberg: トップページ ({_BLOOMBERG_BASE}) を取得中...")
+
+        # ── 待機戦略 ──────────────────────────────────────────────────────────
+        # 旧コード: 'article[class*="story"], article[class*="module"]' を待機
+        #   → Bloomberg はそのクラスを持つ article タグを JS 描画しないため
+        #     常にタイムアウトしていた
+        #
+        # 新コード:
+        #   1. まず body タグ出現を待機（ページ自体の読み込み完了を確認）
+        #   2. さらに <a href> を含む要素が現れるまで短時間待機
+        #   3. JS 描画を待つため追加スリープ
+        # ─────────────────────────────────────────────────────────────────────
+        page_loaded = False
         for attempt in range(scraping_config.selenium_max_retries):
             try:
-                # 段階的タイムアウト: 初回25秒、リトライ時45秒
-                current_timeout = 25 if attempt == 0 else 45
-                wait_with_timeout = WebDriverWait(driver, current_timeout)
-                
-                driver.get(base_url)
-                # 記事要素が読み込まれるまで待機
-                wait_with_timeout.until(EC.presence_of_element_located((By.CSS_SELECTOR, 'article[class*="story"], article[class*="module"]')))
+                current_timeout = 30 if attempt == 0 else 50
+                driver.get(_BLOOMBERG_BASE)
+
+                # body タグの出現を待つ（最低限のページロード確認）
+                WebDriverWait(driver, current_timeout).until(
+                    EC.presence_of_element_located((By.TAG_NAME, "body"))
+                )
+                # JS 描画のための追加待機
+                time.sleep(3)
+                page_loaded = True
                 break
+
             except TimeoutException:
-                print(f"    [!] ページ読み込みタイムアウト ({current_timeout}秒, {attempt + 1}/{scraping_config.selenium_max_retries})。リトライします...")
+                print(
+                    f"    [!] ページ読み込みタイムアウト "
+                    f"({current_timeout}秒, {attempt + 1}/{scraping_config.selenium_max_retries})。"
+                    f"リトライします..."
+                )
                 if attempt + 1 == scraping_config.selenium_max_retries:
-                    print(f"    [!] リトライ上限に達したため、Bloombergのスクレイピングを中止します。")
+                    print("    [!] リトライ上限に達したため、Bloombergのスクレイピングを中止します。")
                     return []
-        
-        soup = BeautifulSoup(driver.page_source, 'html.parser')
-        article_elements = soup.find_all('article', class_=re.compile(r'story|module', re.I))
-        
-        if not article_elements:
-            print("    [!] Bloombergトップページで記事候補が見つかりませんでした。サイト構造を確認してください。")
+
+        if not page_loaded:
             return []
-            
-        print(f"    - トップページで記事候補: {len(article_elements)} 件発見。")
-        
+
+        soup = BeautifulSoup(driver.page_source, 'html.parser')
+
+        # ── 記事要素の抽出 ────────────────────────────────────────────────────
+        # 優先度順にセレクターを試行:
+        #   1. <article> タグ（任意クラス）
+        #   2. クラスに "story" または "module" を含む任意タグ
+        #   3. ニュースリンク (<a href="/news/..."> ) を直接収集
+        # ─────────────────────────────────────────────────────────────────────
+
+        article_elements = soup.find_all('article')
+
+        if not article_elements:
+            # クラスに story / module を含むブロック要素
+            article_elements = soup.find_all(
+                True,
+                class_=re.compile(r'\bstory\b|\bmodule\b', re.I)
+            )
+
         jst = pytz.timezone('Asia/Tokyo')
         now_jst = datetime.now(jst)
         time_threshold_jst = now_jst - timedelta(hours=hours_limit)
 
-        for article_element in article_elements:
-            link_el = article_element.find('a', href=True)
-            if not link_el or not link_el.has_attr('href'): continue
-                
-            raw_url = link_el['href']
-            article_url = base_url + raw_url if raw_url.startswith('/') else raw_url
-            article_url = article_url.split('?')[0].split('#')[0]
+        if article_elements:
+            print(f"    - トップページで記事候補: {len(article_elements)} 件発見。")
+            _extract_from_article_elements(
+                article_elements, processed_urls, articles_to_process,
+                now_jst, time_threshold_jst, exclude_keywords,
+            )
 
-            if not article_url.startswith('http') or article_url in processed_urls: continue
-            processed_urls.add(article_url)
+        # article 要素から記事が取れなかった場合はリンク直接収集にフォールバック
+        if not articles_to_process:
+            print("    [フォールバック] article 要素が空のため、ニュースリンクを直接収集します。")
+            _extract_from_news_links(
+                soup, processed_urls, articles_to_process,
+                now_jst, time_threshold_jst, exclude_keywords,
+            )
 
-            time_tag = article_element.find('time', datetime=True)
-            article_time_jst = now_jst
-            if time_tag and time_tag.has_attr('datetime'):
-                try:
-                    dt_utc = datetime.fromisoformat(time_tag['datetime'].replace('Z', '+00:00'))
-                    article_time_jst = dt_utc.astimezone(jst)
-                except ValueError:
-                    pass # パース失敗時は現在時刻のまま
-
-            if article_time_jst < time_threshold_jst: continue
-
-            title_element = article_element.find(['h1','h2','h3','a'], class_=re.compile(r'story-title', re.I)) or link_el
-            title = title_element.get_text(strip=True)
-            if not title or any(keyword.lower() in title.lower() for keyword in exclude_keywords): continue
-
-            print(f"    > 記事発見: {title}")
-            articles_to_process.append({
-                'source': 'Bloomberg', 'title': title, 'url': article_url,
-                'published_jst': article_time_jst, 'category': "Bloomberg Top"
-            })
+        if not articles_to_process:
+            print("--- Bloomberg: 処理対象の記事が見つかりませんでした ---")
+            # デバッグ情報
+            all_links = soup.find_all('a', href=True)
+            print(f"    [デバッグ] ページ内の全 <a> タグ数: {len(all_links)}")
+            sample = [l['href'] for l in all_links if l['href'].startswith('/')][:10]
+            print(f"    [デバッグ] href サンプル: {sample}")
+            return []
 
     except Exception as e:
-        print(f"  Bloombergスクレイピング処理全体でエラーが発生しました: {e}")
+        print(f"  Bloomberg スクレイピング処理全体でエラーが発生しました: {e}")
     finally:
         if driver:
             driver.quit()
+        try:
+            shutil.rmtree(user_data_dir, ignore_errors=True)
+        except Exception:
+            pass
 
     if not articles_to_process:
-        print("--- Bloomberg: 処理対象の記事が見つかりませんでした ---")
         return []
 
-    print(f"\n--- {len(articles_to_process)}件の記事本文を並列取得開始 (最大{config.bloomberg.num_parallel_requests}スレッド) ---")
+    print(
+        f"\n--- {len(articles_to_process)}件の記事本文を並列取得開始 "
+        f"(最大{config.bloomberg.num_parallel_requests}スレッド) ---"
+    )
     final_articles_data = []
     with ThreadPoolExecutor(max_workers=config.bloomberg.num_parallel_requests) as executor:
-        future_to_article = {executor.submit(scrape_bloomberg_article_body, article['url']): article for article in articles_to_process}
-        
+        future_to_article = {
+            executor.submit(scrape_bloomberg_article_body, article['url']): article
+            for article in articles_to_process
+        }
         for i, future in enumerate(as_completed(future_to_article)):
             article = future_to_article[future]
             try:
                 body = future.result()
                 article['body'] = body or "[本文取得失敗/空]"
                 final_articles_data.append(article)
-                print(f"  ({i+1}/{len(articles_to_process)}) 完了: {article['title']}")
+                print(f"  ({i + 1}/{len(articles_to_process)}) 完了: {article['title']}")
             except Exception as exc:
                 print(f"  [!!] 記事取得中に例外発生 ({article['url']}): {exc}")
                 article['body'] = f"[本文取得エラー: {exc}]"
@@ -234,3 +295,96 @@ def scrape_bloomberg_top_page_articles(hours_limit: int, exclude_keywords: list)
 
     print(f"--- Bloomberg記事取得完了: {len(final_articles_data)} 件 ---")
     return final_articles_data
+
+
+def _extract_from_article_elements(
+    article_elements, processed_urls, articles_to_process,
+    now_jst, time_threshold_jst, exclude_keywords,
+):
+    """<article> / クラス要素から記事情報を抽出する"""
+    for article_element in article_elements:
+        link_el = article_element.find('a', href=True)
+        if not link_el:
+            continue
+
+        raw_url = link_el['href']
+        article_url = (
+            _BLOOMBERG_BASE + raw_url if raw_url.startswith('/') else raw_url
+        )
+        article_url = article_url.split('?')[0].split('#')[0]
+
+        if not article_url.startswith('http') or article_url in processed_urls:
+            continue
+        processed_urls.add(article_url)
+
+        time_tag = article_element.find('time', datetime=True)
+        article_time_jst = now_jst
+        if time_tag and time_tag.has_attr('datetime'):
+            try:
+                dt_utc = datetime.fromisoformat(
+                    time_tag['datetime'].replace('Z', '+00:00')
+                )
+                article_time_jst = dt_utc.astimezone(now_jst.tzinfo)
+            except ValueError:
+                pass
+
+        if article_time_jst < time_threshold_jst:
+            continue
+
+        title_el = (
+            article_element.find(['h1', 'h2', 'h3'], True)
+            or article_element.find('a', class_=re.compile(r'title|headline', re.I))
+            or link_el
+        )
+        title = title_el.get_text(strip=True)
+        if not title or any(kw.lower() in title.lower() for kw in exclude_keywords):
+            continue
+
+        print(f"    > 記事発見: {title}")
+        articles_to_process.append({
+            'source': 'Bloomberg',
+            'title': title,
+            'url': article_url,
+            'published_jst': article_time_jst,
+            'category': 'Bloomberg Top',
+        })
+
+
+def _extract_from_news_links(
+    soup, processed_urls, articles_to_process,
+    now_jst, time_threshold_jst, exclude_keywords,
+):
+    """
+    <a href="/news/..."> を直接収集するフォールバック。
+    article 要素が JS 描画されていない場合に使用。
+    """
+    news_links = soup.find_all(
+        'a',
+        href=re.compile(r'^/(?:news/articles|news/videos|markets|technology|business|economics)/', re.I),
+    )
+    print(f"    [フォールバック] ニュースリンク候補: {len(news_links)} 件")
+
+    for link_el in news_links:
+        raw_url = link_el['href']
+        article_url = _BLOOMBERG_BASE + raw_url if raw_url.startswith('/') else raw_url
+        article_url = article_url.split('?')[0].split('#')[0]
+
+        if article_url in processed_urls:
+            continue
+        processed_urls.add(article_url)
+
+        title = link_el.get_text(strip=True)
+        if not title or len(title) < 10:
+            continue
+        if any(kw.lower() in title.lower() for kw in exclude_keywords):
+            continue
+
+        # リンク収集フォールバックでは時刻情報が取れないため現在時刻を使用
+        print(f"    > 記事発見 [FB]: {title}")
+        articles_to_process.append({
+            'source': 'Bloomberg',
+            'title': title,
+            'url': article_url,
+            'published_jst': now_jst,
+            'category': 'Bloomberg Top',
+        })

--- a/scrapers/reuters.py
+++ b/scrapers/reuters.py
@@ -25,182 +25,222 @@ config = get_config()
 reuters_config = config.reuters
 scraping_config = config.scraping
 
-def scrape_reuters_article_body(article_url: str, timeout: int = 15) -> str:
-    """指定されたロイター記事URLから本文を抽出する"""
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.5',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Connection': 'keep-alive',
-        'Upgrade-Insecure-Requests': '1',
-        'Sec-Fetch-Dest': 'document',
-        'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'none'
-    }
-    
-    # リトライ機能付きで記事本文を取得
-    max_retries = 2
+# ゼロ幅文字などの不可視文字を除去する正規表現
+_INVISIBLE_CHARS = re.compile(r'[\u200b-\u200f\u00ad\u2060\ufeff\u2028\u2029\u180e]')
+
+# 定型文フィルター（共通）
+_BOILERPLATE_PATTERNS = [
+    '信頼の原則',
+    'Thomson Reuters',
+    'トムソン・ロイター',
+    '掲載の情報は',
+    '© 2025 Reuters',
+    '© 2026 Reuters',
+]
+
+
+def _build_chrome_options(user_data_dir: str) -> Options:
+    """Reuters スクレイパー共通の Chrome オプションを生成する"""
+    opts = Options()
+    opts.add_argument("--headless")
+    opts.add_argument("--no-sandbox")
+    opts.add_argument("--disable-dev-shm-usage")
+    opts.add_argument("--disable-gpu")
+    opts.add_argument("--window-size=1920x1080")
+    opts.add_argument(
+        "user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    )
+    opts.add_argument("--blink-settings=imagesEnabled=false")
+    opts.add_argument("--disable-extensions")
+    opts.add_argument("--disable-plugins")
+    opts.add_argument("--disable-web-security")
+    opts.add_argument("--allow-running-insecure-content")
+    opts.add_argument("--disable-features=VizDisplayCompositor")
+    opts.add_argument("--disable-blink-features=AutomationControlled")
+    opts.add_experimental_option("useAutomationExtension", False)
+    opts.add_experimental_option("excludeSwitches", ["enable-automation"])
+    opts.add_experimental_option('prefs', {
+        'profile.default_content_setting_values.notifications': 2,
+        'profile.default_content_settings.popups': 0,
+        'profile.managed_default_content_settings.images': 2,
+    })
+    opts.add_argument(f"--user-data-dir={user_data_dir}")
+    return opts
+
+
+def _extract_body_from_soup(soup: BeautifulSoup, article_url: str) -> str:
+    """
+    BeautifulSoup オブジェクトから記事本文を抽出する。
+    Selenium・requests どちらの取得結果にも使える共通ロジック。
+    """
+    # --- コンテナ特定 ---
+    # 優先度順: data-testid="ArticleBody" → class パターン → article タグ → main タグ
+    body_container = None
+
+    # 1. data-testid="ArticleBody" (現行の確実な構造)
+    body_container = soup.find(attrs={"data-testid": "ArticleBody"})
+
+    if not body_container:
+        container_selectors = [
+            ('div', re.compile(r'article-body-module__content__')),
+            ('div', re.compile(r'article-body-module__container__')),
+            ('div', re.compile(r'article-body__content__')),
+            ('div', re.compile(r'article.*body|body.*content', re.I)),
+            ('article', None),
+            ('div', re.compile(r'story.*body|content.*body', re.I)),
+            ('main', None),
+        ]
+        for tag, class_pattern in container_selectors:
+            if class_pattern:
+                container = soup.find(tag, class_=class_pattern)
+            else:
+                container = soup.find(tag)
+            if container:
+                body_container = container
+                print(f"  [記事本文取得] 本文コンテナ発見: {tag}要素 ({class_pattern})")
+                break
+
+    if not body_container:
+        print(f"  [記事本文取得] 本文コンテナが見つかりません: {article_url}")
+        return ""
+
+    # --- 段落抽出 ---
+    paragraphs = []
+
+    # 1. data-testid="paragraph-N" (現行の確実な構造)
+    para_divs = body_container.find_all(
+        'div', attrs={"data-testid": re.compile(r'^paragraph-\d+$')}
+    )
+    if para_divs:
+        for elem in para_divs:
+            text = _INVISIBLE_CHARS.sub('', elem.get_text(separator=' ', strip=True))
+            if (len(text) > 20
+                    and not any(bp in text for bp in _BOILERPLATE_PATTERNS)):
+                paragraphs.append(text)
+        if paragraphs:
+            print(f"  [記事本文取得] 段落抽出成功 (data-testid=paragraph-N): {len(paragraphs)}個")
+
+    # 2. クラスベースの段落
+    if not paragraphs:
+        paragraph_selectors = [
+            ('p', re.compile(r'article-body-module__paragraph__')),
+            ('p', re.compile(r'article-body-module__element__')),
+            ('p', re.compile(r'text__text__')),
+            ('p', None),
+        ]
+        for tag, class_or_test in paragraph_selectors:
+            if class_or_test:
+                elements = body_container.find_all(tag, class_=class_or_test)
+            else:
+                elements = body_container.find_all(tag)
+
+            if elements:
+                candidates = []
+                for elem in elements:
+                    text = _INVISIBLE_CHARS.sub('', elem.get_text(separator=' ', strip=True))
+                    if (len(text) > 20
+                            and not any(bp in text for bp in _BOILERPLATE_PATTERNS)):
+                        candidates.append(text)
+                if candidates:
+                    paragraphs = candidates
+                    print(f"  [記事本文取得] 段落抽出成功 ({tag}/{class_or_test}): {len(paragraphs)}個")
+                    break
+
+    # 3. 全テキストフォールバック
+    if not paragraphs:
+        print(f"  [記事本文取得] 段落が見つからないため全テキストを使用: {article_url}")
+        full_text = body_container.get_text(separator='\n', strip=True)
+        paragraphs = [
+            _INVISIBLE_CHARS.sub('', line.strip())
+            for line in full_text.split('\n')
+            if line.strip() and len(line.strip()) > 10
+            and not any(bp in line for bp in _BOILERPLATE_PATTERNS)
+        ]
+
+    article_text = '\n'.join(paragraphs)
+
+    # 短すぎる場合は meta description にフォールバック
+    if len(article_text.strip()) < 50:
+        meta_desc = soup.find('meta', attrs={'name': 'description'})
+        if meta_desc and meta_desc.get('content'):
+            fallback = _INVISIBLE_CHARS.sub('', meta_desc['content'].strip())
+            if len(fallback) >= 50:
+                print(f"  [記事本文取得] meta description から取得 (長さ: {len(fallback)}文字): {article_url}")
+                return re.sub(r'\s+', ' ', fallback).strip()
+
+    return re.sub(r'\s+', ' ', article_text).strip()
+
+
+def scrape_reuters_article_body_with_selenium(
+    driver: webdriver.Chrome,
+    article_url: str,
+    selenium_timeout: int = 20,
+) -> str:
+    """
+    既存の Selenium driver を使って記事本文を取得する。
+    401 対策として requests を使わず Selenium 経由でアクセスする。
+    """
+    max_retries = 1  # driver 共有なので過剰リトライは避ける
     for attempt in range(max_retries + 1):
         try:
-            # リトライ時はタイムアウトを延長
-            current_timeout = timeout if attempt == 0 else timeout + 10
-            print(f"  [記事本文取得] URL: {article_url} を処理中... (試行 {attempt + 1}/{max_retries + 1}, タイムアウト: {current_timeout}秒)")
-            
-            response = requests.get(article_url, headers=headers, timeout=current_timeout)
-            response.raise_for_status()
-            response.encoding = response.apparent_encoding
-            
-            soup = BeautifulSoup(response.content, 'html.parser')
-            
-            # 複数の本文コンテナパターンを試行
-            body_container = None
-            container_selectors = [
-                ('div', re.compile(r'article-body-module__content__')),  # 最新の構造
-                ('div', re.compile(r'article-body-module__container__')),  # コンテナ
-                ('div', re.compile(r'article-body__content__')),  # 元の
-                ('div', re.compile(r'article.*body|body.*content', re.I)),  # 汎用
-                ('article', None),  # article要素全体
-                ('div', re.compile(r'story.*body|content.*body', re.I)),  # ストーリー本文
-                ('main', None),  # main要素
-            ]
-            
-            for tag, class_pattern in container_selectors:
-                if class_pattern:
-                    container = soup.find(tag, class_=class_pattern)
-                else:
-                    container = soup.find(tag)
-                if container:
-                    body_container = container
-                    print(f"  [記事本文取得] 本文コンテナ発見: {tag}要素 ({class_pattern})")
-                    break
-                    
-            if not body_container:
-                print(f"  [記事本文取得] 全ての本文コンテナパターンで検索失敗: {article_url}")
-                if attempt < max_retries:
-                    print(f"  [記事本文取得] リトライします...")
-                    time.sleep(2)
-                    continue
-                return ""
-                
-            # 複数の段落抽出パターンを試行
-            paragraphs = []
-            paragraph_selectors = [
-                ('div', 'data-testid-paragraph'),  # 最新構造: data-testid="paragraph-X"
-                ('p', re.compile(r'article-body-module__element__')),  # 新しい構造
-                ('p', re.compile(r'text__text__')),  # 元の
-                ('p', None),  # 全てのp要素
-                ('div', lambda x: x and x.startswith('paragraph-') if isinstance(x, str) else False),  # data-testid
-                ('div', re.compile(r'paragraph|content.*text', re.I)),  # 段落div
-            ]
-            
-            for tag, class_or_test in paragraph_selectors:
-                if class_or_test == 'data-testid-paragraph':  # 最新構造
-                    # data-testid="paragraph-X" パターンの要素を取得
-                    elements = body_container.find_all('div', attrs={"data-testid": re.compile(r'^paragraph-\d+$')})
-                elif callable(class_or_test):  # data-testid用
-                    elements = body_container.find_all('div', attrs={"data-testid": class_or_test})
-                elif class_or_test:  # class pattern
-                    elements = body_container.find_all(tag, class_=class_or_test)
-                else:  # 全て
-                    elements = body_container.find_all(tag)
-                    
-                if elements:
-                    # 定型文をフィルタリングして段落抽出
-                    paragraphs = []
-                    for elem in elements:
-                        text = elem.get_text(separator=' ', strip=True)
-                        # 定型文を除外
-                        if (text and len(text) > 20 and 
-                            '信頼の原則' not in text and 
-                            'Thomson Reuters' not in text and
-                            'トムソン・ロイター' not in text and
-                            '掲載の情報は' not in text and
-                            '© 2025 Reuters' not in text):
-                            paragraphs.append(text)
-                    
-                    if paragraphs:
-                        print(f"  [記事本文取得] 段落抽出成功: {tag}要素 {len(paragraphs)}個")
-                        break
-                        
-            if not paragraphs:
-                print(f"  [記事本文取得] 段落が見つからないため、全テキストを取得: {article_url}")
-                full_text = body_container.get_text(separator='\n', strip=True)
-                paragraphs = [line.strip() for line in full_text.split('\n') if line.strip() and len(line.strip()) > 10]
+            print(
+                f"  [記事本文取得/Selenium] URL: {article_url} "
+                f"(試行 {attempt + 1}/{max_retries + 1})"
+            )
+            driver.get(article_url)
 
-            article_text = '\n'.join(paragraphs)
-            if len(article_text.strip()) < 50:
-                print(f"  [記事本文取得] 取得した本文が短すぎます (長さ: {len(article_text)}文字): {article_url}")
-                # meta descriptionからフォールバック取得を試行
-                meta_desc = soup.find('meta', attrs={'name': 'description'})
-                if meta_desc and meta_desc.get('content'):
-                    fallback_text = meta_desc['content'].strip()
-                    if len(fallback_text) >= 50:
-                        print(f"  [記事本文取得] meta descriptionから取得成功 (長さ: {len(fallback_text)}文字): {article_url}")
-                        return re.sub(r'\s+', ' ', fallback_text).strip()
-                
-                if attempt < max_retries:
-                    print(f"  [記事本文取得] リトライします...")
-                    time.sleep(2)
-                    continue
-            else:
-                print(f"  [記事本文取得] 本文取得成功 (長さ: {len(article_text)}文字): {article_url}")
-            
-            return re.sub(r'\s+', ' ', article_text).strip()
-            
-        except (requests.exceptions.RequestException, requests.exceptions.Timeout) as e:
-            print(f"  [本文取得エラー] ロイター記事 ({article_url}) の取得に失敗 (試行 {attempt + 1}): {e}")
+            # ArticleBody が現れるまで待機（最大 selenium_timeout 秒）
+            try:
+                WebDriverWait(driver, selenium_timeout).until(
+                    EC.presence_of_element_located(
+                        (By.CSS_SELECTOR, '[data-testid="ArticleBody"], [data-testid="Body"]')
+                    )
+                )
+            except TimeoutException:
+                # タイムアウトしても page_source は取得を試みる
+                print(f"  [記事本文取得/Selenium] ArticleBody 待機タイムアウト: {article_url}")
+
+            soup = BeautifulSoup(driver.page_source, 'html.parser')
+            body_text = _extract_body_from_soup(soup, article_url)
+
+            if body_text:
+                print(f"  [記事本文取得/Selenium] 成功 (長さ: {len(body_text)}文字): {article_url}")
+                return body_text
+
+            # 本文が取れなかった場合リトライ
             if attempt < max_retries:
-                print(f"  [記事本文取得] {2}秒後にリトライします...")
+                print(f"  [記事本文取得/Selenium] 本文なし、リトライします...")
                 time.sleep(2)
                 continue
+
         except Exception as e:
-            print(f"  [本文取得エラー] ロイター記事 ({article_url}) の解析中に予期せぬエラー: {e}")
+            print(f"  [記事本文取得/Selenium] エラー ({article_url}): {e}")
             if attempt < max_retries:
-                print(f"  [記事本文取得] リトライします...")
                 time.sleep(2)
                 continue
-    
-    # 全ての試行が失敗した場合
-    print(f"  [本文取得失敗] 全ての試行が失敗しました: {article_url}")
+
+    print(f"  [記事本文取得失敗] 全試行失敗: {article_url}")
     return ""
+
 
 def scrape_reuters_articles(query: str, hours_limit: int, max_pages: int,
                             items_per_page: int, target_categories: list,
                             exclude_keywords: list) -> list:
     """ロイターのサイト内検索を利用して記事情報を収集する"""
-    
+
     base_search_url = "https://jp.reuters.com/site-search/"
-    
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")
-    chrome_options.add_argument("--no-sandbox")
-    chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_argument("--disable-gpu")
-    chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument('user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36')
-    chrome_options.add_argument("--blink-settings=imagesEnabled=false")
-    chrome_options.add_argument("--disable-extensions")
-    chrome_options.add_argument("--disable-plugins")
-    chrome_options.add_argument("--remote-debugging-port=9222")
-    chrome_options.add_argument("--disable-web-security")
-    chrome_options.add_argument("--allow-running-insecure-content")
-    chrome_options.add_argument("--disable-features=VizDisplayCompositor")
-    chrome_options.add_argument("--disable-blink-features=AutomationControlled")
-    chrome_options.add_experimental_option("useAutomationExtension", False)
-    chrome_options.add_experimental_option("excludeSwitches", ["enable-automation"])
-    chrome_options.add_experimental_option('prefs', {
-        'profile.default_content_setting_values.notifications': 2,
-        'profile.default_content_settings.popups': 0,
-        'profile.managed_default_content_settings.images': 2
-    })
-    # ユーザーディレクトリ衝突対策（ワークスペース内に一時プロファイルを作成）
-    user_data_dir = tempfile.mkdtemp(prefix="chrome-profile-", dir=str(Path.cwd()))
-    chrome_options.add_argument(f"--user-data-dir={user_data_dir}")
+
+    # Chrome プロファイルを一時ディレクトリに作成（他インスタンスとの衝突を防ぐ）
+    user_data_dir = tempfile.mkdtemp(prefix="chrome-reuters-", dir=str(Path.cwd()))
+    chrome_options = _build_chrome_options(user_data_dir)
+    # 記事一覧ページと本文ページの両方を同一 driver で扱うため
+    # remote-debugging-port は衝突回避のためポートを固定しない
+    chrome_options.add_argument("--remote-debugging-port=0")
 
     driver = None
     print("\n--- ロイター記事のスクレイピング開始 ---")
-    
+
     articles_to_process = []
     processed_urls = set()
 
@@ -208,45 +248,60 @@ def scrape_reuters_articles(query: str, hours_limit: int, max_pages: int,
         driver = webdriver.Chrome(options=chrome_options)
         driver.set_page_load_timeout(scraping_config.page_load_timeout)
         driver.implicitly_wait(scraping_config.implicit_wait)
-        wait = WebDriverWait(driver, scraping_config.selenium_timeout)
-        
+
         jst = pytz.timezone('Asia/Tokyo')
         time_threshold_jst = datetime.now(jst) - timedelta(hours=hours_limit)
 
+        # ────────────────────────────────────────────
+        # Step 1: 記事一覧をスクレイピング
+        # ────────────────────────────────────────────
         for page_num in range(max_pages):
             offset = page_num * items_per_page
-            search_url = f"{base_search_url}?query={requests.utils.quote(query)}&offset={offset}"
+            search_url = (
+                f"{base_search_url}"
+                f"?query={requests.utils.quote(query)}&offset={offset}"
+            )
             print(f"  ロイター: ページ {page_num + 1}/{max_pages} を処理中 ({search_url})...")
 
+            page_loaded = False
             for attempt in range(scraping_config.selenium_max_retries):
                 try:
-                    # 段階的タイムアウト: 初回30秒、リトライ時50秒
                     current_timeout = 30 if attempt == 0 else 50
                     wait_with_timeout = WebDriverWait(driver, current_timeout)
-                    
                     driver.get(search_url)
-                    # 記事要素が読み込まれるまで待機
-                    wait_with_timeout.until(EC.presence_of_element_located((By.CSS_SELECTOR, 'li[data-testid="StoryCard"]')))
-                    break 
+                    wait_with_timeout.until(
+                        EC.presence_of_element_located(
+                            (By.CSS_SELECTOR, 'li[data-testid="StoryCard"]')
+                        )
+                    )
+                    page_loaded = True
+                    break
                 except TimeoutException:
-                    print(f"    [!] ページ読み込みタイムアウト ({current_timeout}秒, {attempt + 1}/{scraping_config.selenium_max_retries})。リトライします...")
+                    print(
+                        f"    [!] ページ読み込みタイムアウト "
+                        f"({current_timeout}秒, {attempt + 1}/{scraping_config.selenium_max_retries})。"
+                        f"リトライします..."
+                    )
                     if attempt + 1 == scraping_config.selenium_max_retries:
-                        print(f"    [!] リトライ上限に達したため、このページ ({search_url}) をスキップします。")
-                        # continue to the next page_num
-                        break  
-            else: # for-else: break しなかった場合 (リトライ全部失敗)
+                        print(
+                            f"    [!] リトライ上限に達したため、"
+                            f"このページ ({search_url}) をスキップします。"
+                        )
+
+            if not page_loaded:
                 continue
 
             soup = BeautifulSoup(driver.page_source, 'html.parser')
             articles_on_page = soup.find_all('li', attrs={"data-testid": "StoryCard"})
-            
+
             print(f"    - ページで見つかった記事候補: {len(articles_on_page)}件")
-            
+
             if not articles_on_page:
                 if page_num == 0:
                     print("    [!] 最初のページで記事が見つかりませんでした。サイト構造が変更された可能性があります。")
-                    # デバッグ用: 他の可能性のあるセレクターを試す
-                    fallback_articles = soup.find_all('li', class_=lambda x: x and 'search-result' in x.lower())
+                    fallback_articles = soup.find_all(
+                        'li', class_=lambda x: x and 'search-result' in x.lower()
+                    )
                     print(f"    [デバッグ] フォールバック検索結果: {len(fallback_articles)}件")
                 else:
                     print(f"    - ページ{page_num + 1}で記事が見つからなかったため処理を終了します。")
@@ -255,93 +310,110 @@ def scrape_reuters_articles(query: str, hours_limit: int, max_pages: int,
             articles_found_on_page = 0
             for article_li in articles_on_page:
                 link_element = article_li.find('a', attrs={"data-testid": "TitleLink"})
-                if not link_element: 
-                    print(f"    [デバッグ] リンク要素が見つからない記事をスキップ")
+                if not link_element:
+                    print("    [デバッグ] リンク要素が見つからない記事をスキップ")
                     continue
 
                 article_url = link_element.get('href', '')
                 if not article_url.startswith('http'):
                     article_url = "https://jp.reuters.com" + article_url
-                
-                if article_url in processed_urls: 
+
+                if article_url in processed_urls:
                     print(f"    [デバッグ] 重複URL をスキップ: {article_url}")
                     continue
                 processed_urls.add(article_url)
-                
-                # タイトルを取得してログ出力
-                title = link_element.get_text(strip=True) if link_element else "タイトル不明"
+
+                title = link_element.get_text(strip=True) or "タイトル不明"
                 print(f"    > 記事候補発見: {title}")
                 articles_found_on_page += 1
 
                 time_element = article_li.find('time', attrs={"data-testid": "DateLineText"})
                 try:
-                    dt_utc = datetime.fromisoformat(time_element.get('datetime').replace('Z', '+00:00'))
+                    dt_utc = datetime.fromisoformat(
+                        time_element.get('datetime').replace('Z', '+00:00')
+                    )
                     article_time_jst = dt_utc.astimezone(jst)
                 except (ValueError, AttributeError):
                     print(f"    [デバッグ] 時刻解析失敗のためスキップ: {title}")
                     continue
 
-                if article_time_jst < time_threshold_jst: 
+                if article_time_jst < time_threshold_jst:
                     print(f"    [デバッグ] 時間制限外のためスキップ: {title} ({article_time_jst})")
                     continue
 
                 title_text = link_element.get_text(strip=True)
-                if any(keyword.lower() in title_text.lower() for keyword in exclude_keywords): 
+                if any(kw.lower() in title_text.lower() for kw in exclude_keywords):
                     print(f"    [デバッグ] 除外キーワードでスキップ: {title_text}")
                     continue
 
                 kicker = article_li.find('span', attrs={"data-testid": "KickerLabel"})
-                category_text = kicker.get_text(strip=True).replace(" category", "") if kicker else "不明"
-                
-                if target_categories and category_text not in target_categories: 
+                category_text = (
+                    kicker.get_text(strip=True).replace(" category", "")
+                    if kicker else "不明"
+                )
+
+                if target_categories and category_text not in target_categories:
                     print(f"    [デバッグ] カテゴリ対象外でスキップ: {title_text} (カテゴリ: {category_text})")
                     continue
 
                 print(f"    > 記事発見: {title_text}")
                 articles_to_process.append({
-                    'source': 'Reuters', 'title': title_text, 'url': article_url,
-                    'published_jst': article_time_jst, 'category': category_text
+                    'source': 'Reuters',
+                    'title': title_text,
+                    'url': article_url,
+                    'published_jst': article_time_jst,
+                    'category': category_text,
                 })
 
-            print(f"    - ページ{page_num + 1}の処理完了: 候補{articles_found_on_page}件中、条件に合致した記事数を追加")
-            
+            print(
+                f"    - ページ{page_num + 1}の処理完了: "
+                f"候補{articles_found_on_page}件中、条件に合致した記事数を追加"
+            )
+
             if len(articles_on_page) < items_per_page:
                 print("    [i] 記事がページあたりのアイテム数より少ないため、最終ページと判断し終了します。")
                 break
-            
-            time.sleep(1) # サーバー負荷軽減のための短い待機
+
+            time.sleep(1)
+
+        if not articles_to_process:
+            print("--- ロイター: 処理対象の記事が見つかりませんでした ---")
+            return []
+
+        # ────────────────────────────────────────────
+        # Step 2: 同一 driver で記事本文を順次取得
+        #         （401 対策: requests を使わず Selenium 経由）
+        # ────────────────────────────────────────────
+        print(
+            f"\n--- {len(articles_to_process)}件の記事本文を Selenium で順次取得開始 ---"
+        )
+
+        final_articles_data = []
+        for i, article in enumerate(articles_to_process):
+            try:
+                body = scrape_reuters_article_body_with_selenium(
+                    driver, article['url'],
+                    selenium_timeout=scraping_config.selenium_timeout,
+                )
+                article['body'] = body if body else "[本文取得失敗/空]"
+                final_articles_data.append(article)
+                print(f"  ({i + 1}/{len(articles_to_process)}) 完了: {article['title']}")
+            except Exception as exc:
+                print(f"  [!!] 記事取得中に例外発生 ({article['url']}): {exc}")
+                article['body'] = f"[本文取得エラー: {exc}]"
+                final_articles_data.append(article)
 
     except Exception as e:
         print(f"  ロイタースクレイピングのブラウザ操作中に予期せぬエラーが発生しました: {e}")
     finally:
         if driver:
             driver.quit()
-
-    if not articles_to_process:
-        print("--- ロイター: 処理対象の記事が見つかりませんでした ---")
-        return []
-
-    print(f"\n--- {len(articles_to_process)}件の記事本文を並列取得開始 (最大{reuters_config.num_parallel_requests}スレッド) ---")
-    
-    final_articles_data = []
-    with ThreadPoolExecutor(max_workers=reuters_config.num_parallel_requests) as executor:
-        future_to_article = {executor.submit(scrape_reuters_article_body, article['url']): article for article in articles_to_process}
-        
-        for i, future in enumerate(as_completed(future_to_article)):
-            article = future_to_article[future]
-            try:
-                body = future.result()
-                if body:
-                    article['body'] = body
-                    final_articles_data.append(article)
-                else:
-                    article['body'] = "[本文取得失敗/空]"
-                    final_articles_data.append(article) # 本文がなくても追加
-                print(f"  ({i+1}/{len(articles_to_process)}) 完了: {article['title']}")
-            except Exception as exc:
-                print(f"  [!!] 記事取得中に例外発生 ({article['url']}): {exc}")
-                article['body'] = f"[本文取得エラー: {exc}]"
-                final_articles_data.append(article)
+        # 一時プロファイルディレクトリを削除
+        try:
+            import shutil
+            shutil.rmtree(user_data_dir, ignore_errors=True)
+        except Exception:
+            pass
 
     print(f"--- ロイター記事取得完了: {len(final_articles_data)} 件 ---")
     return final_articles_data


### PR DESCRIPTION
## 概要

2026-05-05 の GitHub Actions 失敗を修正します。

## 失敗原因

### ① Reuters: 記事本文 401 Unauthorized
- GitHub Actions ランナーの IP が `jp.reuters.com` への `requests` アクセスを **401 でブロック**するようになった
- 記事一覧（Selenium 経由）は 93 件取得できていたが、本文取得（requests 経由）が全件失敗
- 2 回目以降のスクレイピングで Reuters も 0 件になり、最終的に `articles_found=0` で `RuntimeError`

### ② Bloomberg: Selenium 待機セレクターが常に失敗
- 待機セレクター `article[class*="story"], article[class*="module"]` が Bloomberg のサイト構造と一致しておらず、**以前から常にタイムアウト**していた
- 前日までは Reuters が単独で閾値を超えていたため顕在化していなかった

## 修正内容

### scrapers/reuters.py
| 変更点 | 旧 | 新 |
|--------|----|----|
| 本文取得手段 | `requests.get()` → 401 ブロック | 同一 Selenium driver 経由 |
| 並列処理 | `ThreadPoolExecutor` で並列取得 | driver 共有のため順次処理 |
| 本文抽出 | `_extract_body_from_soup()` で共通化 | ゼロ幅文字除去・定型文フィルター強化 |
| Chrome profile | `--remote-debugging-port=9222` 固定 | `--remote-debugging-port=0`（競合回避）+ 終了時 `shutil.rmtree` |

**新フロー:**
1. Selenium driver 1 本で記事一覧をページング取得（従来通り）
2. **同じ driver** で記事本文ページに順次アクセス → `[data-testid="ArticleBody"]` を待機してからスクレイプ

### scrapers/bloomberg.py
| 変更点 | 旧 | 新 |
|--------|----|----|
| Selenium 待機 | `article[class*="story"]` → 常にタイムアウト | `body` タグ出現確認 + 3 秒 JS 描画待機 |
| 記事抽出 | `article[class*=story\|module]` のみ | 3 段階フォールバック |

**新フォールバック順序:**
1. `<article>` タグ（任意クラス）
2. class に `story` / `module` を含む任意タグ
3. `href=/news/...` のリンクを直接収集（JS 未描画時）

## テスト確認
- `scrapers/reuters.py`: 構文 OK、呼び出しシグネチャ一致確認済み
- `scrapers/bloomberg.py`: 構文 OK、呼び出しシグネチャ一致確認済み
- `news_processor.py` の呼び出し箇所 (`scrape_reuters_articles` / `scrape_bloomberg_top_page_articles`) は変更なし