### PR TITLE
fix(config): Reutersスクレイパー設定最適化でタイムアウト対策

### DIFF
--- a/src/config/app_config.py
+++ b/src/config/app_config.py
@@ -20,10 +20,10 @@ class ScrapingConfig:
 
     hours_limit: int = 24
     sentiment_analysis_enabled: bool = os.getenv("SCRAPING_SENTIMENT_ANALYSIS_ENABLED", "false").lower() == "true"  # 感情分析を環境変数で制御
-    selenium_timeout: int = 20  # Seleniumの基本タイムアウト（秒）- 45→20秒に短縮
-    selenium_max_retries: int = 3  # ページ読み込みのリトライ回数
-    page_load_timeout: int = 30  # ページ読み込み専用タイムアウト（秒）- 60→30秒に短縮
-    implicit_wait: int = 5  # 暗黙的待機時間（秒）- 10→5秒に短縮
+    selenium_timeout: int = 15  # Seleniumの基本タイムアウト（秒）- 20→15秒に短縮
+    selenium_max_retries: int = 2  # ページ読み込みのリトライ回数 - 3→2回に削減
+    page_load_timeout: int = 20  # ページ読み込み専用タイムアウト（秒）- 30→20秒に短縮
+    implicit_wait: int = 3  # 暗黙的待機時間（秒）- 5→3秒に短縮
 
     # 動的記事取得機能
     minimum_article_count: int = 100  # 最低記事数閾値
@@ -36,7 +36,7 @@ class ReutersConfig:
     """ロイター設定"""
 
     query: str = "米 OR 金融 OR 経済 OR 株価 OR FRB OR FOMC OR 決算 OR 利上げ OR インフレ"
-    max_pages: int = 5
+    max_pages: int = 3  # 5→3ページに削減（タイムアウト対策）
     items_per_page: int = 20
     num_parallel_requests: int = 8  # 記事本文を並列取得する際のスレッド数
     target_categories: List[str] = field(


### PR DESCRIPTION
## 修正内容

### 問題の原因
GitHub Actions の **「Run script」ステップが15分でタイムアウト**していました。

ログ分析の結果：
- Reutersスクレイピング: max_pages=5 × retry=3 × 30-50秒 = 最大**7.5分**を記事一覧だけで消費
- その後の記事本文取得でさらに時間がかかり、合計15分超過

### このPRの修正（src/config/app_config.py）
```
max_pages:          5 → 3   （記事一覧取得ページ数削減）
selenium_max_retries: 3 → 2 （リトライ回数削減）
page_load_timeout:  30 → 20秒（ページ読み込み待機短縮）
selenium_timeout:   20 → 15秒（Selenium待機短縮）
implicit_wait:       5 → 3秒 （暗黙的待機短縮）
```

### ワークフローファイルの追加修正が必要（権限不足のため別途対応）
以下2点はローカルに変更済みですが、workflows権限が不足しているためこのPRに含められていません：

1. **social-content.yml** - YAML構文エラー修正
   - step名の  が YAML パースエラーを引き起こしていた
   - `Fallback: skip...` → `Fallback - skip...`

2. **main.yml** - timeout-minutes を 15 → 25分に延長
   - Reutersスクレイピングの時間確保のため
