### PR TITLE
revert(config): Reutersスクレイパー設定を元の値に戻す

### DIFF
--- a/src/config/app_config.py
+++ b/src/config/app_config.py
@@ -20,10 +20,10 @@ class ScrapingConfig:
 
     hours_limit: int = 24
     sentiment_analysis_enabled: bool = os.getenv("SCRAPING_SENTIMENT_ANALYSIS_ENABLED", "false").lower() == "true"  # 感情分析を環境変数で制御
-    selenium_timeout: int = 15  # Seleniumの基本タイムアウト（秒）- 20→15秒に短縮
-    selenium_max_retries: int = 2  # ページ読み込みのリトライ回数 - 3→2回に削減
-    page_load_timeout: int = 20  # ページ読み込み専用タイムアウト（秒）- 30→20秒に短縮
-    implicit_wait: int = 3  # 暗黙的待機時間（秒）- 5→3秒に短縮
+    selenium_timeout: int = 20  # Seleniumの基本タイムアウト（秒）
+    selenium_max_retries: int = 3  # ページ読み込みのリトライ回数
+    page_load_timeout: int = 30  # ページ読み込み専用タイムアウト（秒）
+    implicit_wait: int = 5  # 暗黙的待機時間（秒）
 
     # 動的記事取得機能
     minimum_article_count: int = 100  # 最低記事数閾値
@@ -36,7 +36,7 @@ class ReutersConfig:
     """ロイター設定"""
 
     query: str = "米 OR 金融 OR 経済 OR 株価 OR FRB OR FOMC OR 決算 OR 利上げ OR インフレ"
-    max_pages: int = 3  # 5→3ページに削減（タイムアウト対策）
+    max_pages: int = 5
     items_per_page: int = 20
     num_parallel_requests: int = 8  # 記事本文を並列取得する際のスレッド数
     target_categories: List[str] = field(


### PR DESCRIPTION
## 修正内容

前回のPR #33で誤って削減したReutersスクレイパーの設定を元の値に戻します。

### 変更内容

| パラメータ | PR #33の誤った値 | 元の値（今回） |
|---|---|---|
| `max_pages` | 3 | **5** |
| `selenium_max_retries` | 2 | **3** |
| `page_load_timeout` | 20秒 | **30秒** |
| `selenium_timeout` | 15秒 | **20秒** |
| `implicit_wait` | 3秒 | **5秒** |

### 経緯
タイムアウト問題への対応として誤って記事取得数に影響するパラメータを変更してしまいました。
記事取得数に影響する設定は変更しない方針に従い、すべて元の値に復元します。

### タイムアウト問題の正しい対応
- `.github/workflows/main.yml` の `timeout-minutes` を **15分→25分** に延長（workflows権限が必要なためユーザー様に手動対応をお願いします）
- `.github/workflows/social-content.yml` のYAML構文エラー修正（同上）
