### PR TITLE
fix(ci): quote social workflow fallback step

### DIFF
--- a/.github/workflows/social-content.yml
+++ b/.github/workflows/social-content.yml
@@ -103,7 +103,7 @@ jobs:
         echo "🚀 Generating social assets from DB (artifact valid)"
         python scripts/dev/generate_from_db.py
 
-    - name: Fallback: skip content generation when DB missing/corrupt
+    - name: "Fallback: skip content generation when DB missing/corrupt"
       if: steps.validate-db.outputs.db_valid != 'true'
       run: |
         echo "⚠️ Skipping content generation because database artifact is missing or invalid"


### PR DESCRIPTION
### Motivation
- Fix a YAML parse error in the Social Content workflow caused by an unquoted step `name` that contained a colon, which prevented the workflow from being loaded.

### Description
- Quote the fallback step name in `.github/workflows/social-content.yml` to `- name: "Fallback: skip content generation when DB missing/corrupt"` so the colon is treated as part of the string and the file parses as valid YAML.

### Testing
- Validated all workflow files with `python - <<'PY' ... yaml.safe_load(...) ... PY` (all workflows parsed OK) and ran `git diff --check` with no issues, and attempted to run `actionlint` but its install failed here due to the Go module proxy returning `Forbidden`, so `actionlint` could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca59ab2fc8333b0479372257c2549)